### PR TITLE
Updatingpackage.json to allow npm import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "name": "jquery-date-dropdowns",
+  "version": "1.0.0",
+  "homepage": "https://github.com/IckleChris/jquery-date-dropdowns",
+  "authors": [
+    "Chris Brown <chris1990@live.co.uk>"
+  ],
+  "description": "A simple, customisable date select plugin",
   "private": true,
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Bower is going away, let's give npm and Yarn a chance. 
currently, the error when trying to add the repo using yarn is
error Package "undefined@undefined" doesn't have a "name".